### PR TITLE
Fix: Register User tab content not visible

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -406,7 +406,8 @@ tr:nth-child(even) {
 .enhanced-tabs input[type="radio"]:nth-of-type(2):checked ~ #content2,
 .enhanced-tabs input[type="radio"]:nth-of-type(3):checked ~ #content3,
 .enhanced-tabs input[type="radio"]:nth-of-type(4):checked ~ #content4,
-.enhanced-tabs input[type="radio"]:nth-of-type(5):checked ~ #content5 {
+.enhanced-tabs input[type="radio"]:nth-of-type(5):checked ~ #content5,
+.enhanced-tabs input[type="radio"]:nth-of-type(6):checked ~ #content6 {
     display: block;
 }
 


### PR DESCRIPTION
I modified css/admin.css to include a CSS rule for #content6, making the Register User tab content visible when you select the tab.