### PR TITLE
feat: Add account deletion functionality to admin panel

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -130,6 +130,7 @@
                             <th onclick="sortTable('accountTable', 3)">Status</th>
                             <th onclick="sortTable('accountTable', 4)">Roles</th>
                             <th onclick="sortTable('accountTable', 5)">Last Active</th>
+                            <th>Actions</th>
                         </tr>
                     </thead>
                     <tbody id="accountTable"></tbody>

--- a/js/admin.js
+++ b/js/admin.js
@@ -281,6 +281,7 @@ class PoolpartyAdmin {
                     <td>${this.createStatusBadge(acc.verifiedMail)}</td>
                     <td>${acc.roles || ''}</td>
                     <td>${this.formatDate(acc.lastActivity)}</td>
+                    <td><button class="action-btn btn-danger" onclick="admin.showDeleteConfirm('account', acc.id, acc.name)">Delete</button></td>
                 </tr>`,
             
             registration: (reg) => `
@@ -507,7 +508,8 @@ class PoolpartyAdmin {
         const endpoints = {
             registration: `admin/poolparty/registration/${id}`,
             item: `admin/poolparty/item/${id}`,
-            volunteer: `admin/poolparty/volunteer/${id}`
+            volunteer: `admin/poolparty/volunteer/${id}`,
+            account: `admin/poolparty/account/${id}` // New entry
         };
 
         try {


### PR DESCRIPTION
This commit introduces the ability for administrators to delete user accounts from the admin panel.

Changes include:
- Added a "Delete" button to each row in the "Accounts" table in `admin.html`.
- Added an "Actions" column header to the "Accounts" table for consistency.
- Modified the existing `deleteItem` function in `js/admin.js` to handle the 'account' type:
    - Added `admin/poolparty/account/:id` to the API endpoint mapping.
    - Ensured that local state (`this.state.data.account`), table rendering (`this.renderTable('account')`), and statistics (`this.updateStats()`) are correctly updated after an account is deleted.
- The existing `showDeleteConfirm` function is used to prompt the admin for confirmation before deleting an account.

Conceptual tests have been outlined to cover UI changes, JavaScript logic (mocking API calls), and integration aspects of the new feature.