### PR TITLE
Fix: Correctly pass parameters for account deletion

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -281,7 +281,7 @@ class PoolpartyAdmin {
                     <td>${this.createStatusBadge(acc.verifiedMail)}</td>
                     <td>${acc.roles || ''}</td>
                     <td>${this.formatDate(acc.lastActivity)}</td>
-                    <td><button class="action-btn btn-danger" onclick="admin.showDeleteConfirm('account', acc.id, acc.name)">Delete</button></td>
+                    <td><button class="action-btn btn-danger" onclick="admin.showDeleteConfirm('account', ${acc.id}, '${String(acc.name).replace(/'/g, "\\'")}')">Delete</button></td>
                 </tr>`,
             
             registration: (reg) => `


### PR DESCRIPTION
The onclick handler for account deletion in the admin panel was attempting to access the `acc` object directly, which was out of scope at the time of execution. This resulted in a ReferenceError.

This commit modifies `js/admin.js` to embed the `acc.id` and `acc.name` values directly into the `onclick` string generated in the `renderTableRow` function for accounts. The `acc.name` is now properly stringified and escaped to handle names containing special characters like single quotes.

This resolves the ReferenceError and ensures that account deletion can be triggered correctly from the admin panel.