### PR TITLE
fix: correct 2026 poolparty date

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The official site for **JP Poolparty** — an annual event in Ramsen, Germany. Static, hand-drawn, vanilla-JS, no build step.
 
-🌐 **Production**: <https://poolparty.jupeters.de> · 📅 **Save the date**: Samstag, 04. Juli 2026 · 📍 Kolpingwiese Ramsen
+🌐 **Production**: <https://poolparty.jupeters.de> · 📅 **Save the date**: Samstag, 27. Juni 2026 · 📍 Kolpingwiese Ramsen
 
 The backend that powers login, registration, and the admin dashboard lives at [`LoggeL/jpCore`](https://github.com/LoggeL/jpCore).
 

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
                 </svg>
                 Wann?
               </td>
-              <td>Samstag, 04. Juli 2026 ab 16:00 Uhr.</td>
+              <td>Samstag, 27. Juni 2026 ab 16:00 Uhr.</td>
             </tr>
 
             <tr>


### PR DESCRIPTION
Correct the 2026 Poolparty date from July 4 to June 27 in the public site and README.