### PR TITLE
Fix gallery masonry layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1081,9 +1081,10 @@ span.background-success, span.background-danger {
 
 /* ===== Photo Gallery ===== */
 .photos {
+  --photo-columns: 4;
+  --photo-gap: 14px;
   line-height: 0;
-  column-count: 4;
-  column-gap: 14px;
+  position: relative;
   margin: 2rem 0;
 }
 
@@ -1139,9 +1140,10 @@ span.background-success, span.background-danger {
 }
 
 .photos > div {
-  break-inside: avoid;
-  margin-bottom: 14px;
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0;
 }
 
 .photos img {
@@ -1149,7 +1151,7 @@ span.background-success, span.background-danger {
   height: auto;
   border: 3px solid var(--pencil);
   border-radius: var(--wobbly-sm);
-  margin-bottom: 14px;
+  margin: 0;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   cursor: pointer;
   box-shadow: var(--shadow-sm);
@@ -1190,18 +1192,18 @@ span.background-success, span.background-danger {
 }
 
 @media (max-width: 1000px) {
-  .photos { column-count: 3; }
+  .photos { --photo-columns: 3; }
   .recap-placeholder-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
 @media (max-width: 800px) {
-  .photos { column-count: 2; column-gap: 10px; }
-  .photos img { margin-bottom: 10px; border-width: 2px; }
+  .photos { --photo-columns: 2; --photo-gap: 10px; }
+  .photos img { border-width: 2px; }
   .recap-placeholder-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
 }
 
 @media (max-width: 400px) {
-  .photos { column-count: 1; }
+  .photos { --photo-columns: 1; }
   .recap-placeholder-grid { grid-template-columns: 1fr; }
 }
 
@@ -1708,8 +1710,6 @@ ol li {
   }
 
   .photos {
-    column-count: 2;
-    column-gap: 10px;
     margin: 1rem 0;
   }
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <meta property="og:type" content="website" />
 
     <!-- CSS -->
-    <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/main.css?v=20260718-masonry3" />
 
     <!-- Favicon -->
     <meta name="theme-color" content="#fdfbf7" />
@@ -772,7 +772,7 @@ c0.526-0.559,0.853-1.195,1.115-1.852C14.427,11.544,13.946,12.058,13.396,12.382z"
       >
     </div>
 
-    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/main.js?v=20260718-masonry3"></script>
     <script src="js/fslightbox.min.js"></script>
 
     <!-- Ackee Analytics -->

--- a/js/main.js
+++ b/js/main.js
@@ -243,6 +243,70 @@ if (ACTIVE) {
 }
 
 // ===== Photo gallery =====
+const pendingPhotoLayouts = new Set();
+let photoLayoutFrame;
+
+function layoutPhotoGallery(gallery) {
+  const items = [...gallery.children];
+  if (!items.length || !gallery.clientWidth) return;
+
+  const styles = getComputedStyle(gallery);
+  const columnCount = Math.max(1, Number.parseInt(styles.getPropertyValue('--photo-columns'), 10) || 1);
+  const gap = Number.parseFloat(styles.getPropertyValue('--photo-gap')) || 0;
+  const columnWidth = (gallery.clientWidth - gap * (columnCount - 1)) / columnCount;
+
+  for (const item of items) {
+    item.style.width = `${columnWidth}px`;
+  }
+
+  const columns = Array.from({ length: columnCount }, () => ({ height: 0, items: [] }));
+  const measuredItems = items
+    .map((item, index) => ({ element: item, height: item.offsetHeight, index }))
+    .sort((first, second) => second.height - first.height || first.index - second.index);
+
+  for (const item of measuredItems) {
+    const shortestColumn = columns.reduce(
+      (shortest, column) => (column.height < shortest.height ? column : shortest),
+      columns[0],
+    );
+    shortestColumn.items.push(item);
+    shortestColumn.height += item.height + gap;
+  }
+
+  for (const column of columns) {
+    column.items.sort((first, second) => first.index - second.index);
+  }
+  columns.sort(
+    (first, second) => (first.items[0]?.index ?? Number.POSITIVE_INFINITY)
+      - (second.items[0]?.index ?? Number.POSITIVE_INFINITY),
+  );
+
+  for (const [columnIndex, column] of columns.entries()) {
+    let top = 0;
+    for (const item of column.items) {
+      item.element.style.left = `${columnIndex * (columnWidth + gap)}px`;
+      item.element.style.top = `${top}px`;
+      top += item.height + gap;
+    }
+  }
+
+  gallery.style.height = `${Math.max(...columns.map((column) => column.height)) - gap}px`;
+}
+
+function schedulePhotoLayout(gallery) {
+  if (!gallery) return;
+  pendingPhotoLayouts.add(gallery);
+  if (photoLayoutFrame) return;
+
+  photoLayoutFrame = requestAnimationFrame(() => {
+    for (const pendingGallery of pendingPhotoLayouts) {
+      layoutPhotoGallery(pendingGallery);
+    }
+    pendingPhotoLayouts.clear();
+    photoLayoutFrame = undefined;
+  });
+}
+
 function createPhotos(year, count) {
   const photos = document.getElementById('photos' + year);
   let photosString = '';
@@ -256,6 +320,7 @@ function createPhotos(year, count) {
         `;
   }
   photos.innerHTML = photosString;
+  schedulePhotoLayout(photos);
 }
 
 // Exposed on window so the inline onload="thumbnailHandler(this)" in the gallery HTML keeps working.
@@ -270,6 +335,7 @@ window.thumbnailHandler = function thumbnailHandler(elem) {
   } else {
     elem.classList.remove('thumb');
   }
+  schedulePhotoLayout(elem.closest('.photos'));
 };
 
 let imgType = 'jpg';
@@ -283,6 +349,10 @@ createPhotos(2020, 25);
 createPhotos(2019, 18);
 createPhotos(2018, 7);
 window.refreshFsLightbox?.();
+
+window.addEventListener('resize', () => {
+  document.querySelectorAll('.photos').forEach(schedulePhotoLayout);
+});
 
 // ===== Submit modal (registration only) =====
 let submitData;


### PR DESCRIPTION
## Was wurde geändert?

- das spaltenbasierte Galerie-Layout durch eine echte Masonry-Verteilung ersetzt
- Bilder nach Höhe auf die jeweils kürzeste Spalte verteilt
- responsive Spaltenzahlen für Desktop, Tablet und Mobilgeräte beibehalten
- Galerie bei Bildladevorgängen und Fenstergrößenänderungen neu berechnet
- CSS- und JavaScript-URLs zur Cache-Aktualisierung versioniert

## Warum?

Das bisherige CSS-Column-Layout konnte hohe Portraitbilder nicht gleichmäßig verteilen. Dadurch endeten die Spalten der Galerie deutlich versetzt.

## Auswirkung

Die Galerie nutzt den verfügbaren Platz gleichmäßiger, ohne die DOM- oder Lightbox-Reihenfolge zu verändern. Auf Mobilgeräten wird bei maximal 400 Pixeln korrekt auf eine Spalte gewechselt.

## Prüfung

- Desktop: vier Spalten, Differenz der Spaltenenden von ca. 530 px auf 71 px reduziert
- Tablet: zwei Spalten, Differenz 1 px
- Mobile: eine Spalte, kein horizontaler Overflow
- Lightbox lokal im Browser geprüft
- `node --check js/main.js`
- `git diff --check`
