### PR TITLE
Update featuring images

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,20 +102,20 @@
 
       <div class="featuring-grid">
         <div class="feature-card">
-          <img src="img/2020/medium/img16.jpg" alt="DJ Jesus" />
-          <div class="feature-label">DJ Jesus</div>
+          <img src="img/2026/medium/img6.jpg" alt="Don't tell the others auf der Bühne" />
+          <div class="feature-label">Don't tell the others</div>
         </div>
         <div class="feature-card">
-          <img src="img/2020/medium/img4.jpg" alt="Pool" />
+          <img src="img/2025/medium/img9.jpg" alt="Gäste im Pool" />
           <div class="feature-label">Pool</div>
         </div>
         <div class="feature-card">
-          <img src="img/2023/medium/img1.jpg" alt="Drinks" />
-          <div class="feature-label">Drinks</div>
+          <img src="img/2026/medium/img7.jpg" alt="Bar bei der Poolparty" />
+          <div class="feature-label">Bar</div>
         </div>
         <div class="feature-card">
-          <img src="img/2024/medium/img3.jpg" alt="Band" />
-          <div class="feature-label">Dont tell the others</div>
+          <img src="img/2026/medium/img10.jpg" alt="Gäste auf der Tanzfläche" />
+          <div class="feature-label">Tanzfläche</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Zusammenfassung

- ersetzt die vier Featuring-Bilder durch aktuellere Motive
- zeigt Don't tell the others als Bandfoto auf der Bühne
- gibt dem Pool-Motiv mit mehreren Gästen mehr Energie
- aktualisiert Bar und Tanzfläche mit Motiven aus 2026

## Prüfung

- `git diff --check`
- visuelle Prüfung der vier Karten im Browser
